### PR TITLE
Anime slash command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-alpine
 
-LABEL Name=Searcharr Version=1.1
+LABEL Name=Searcharr Version=1.2
 
 WORKDIR /app
 ADD . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-alpine
 
-LABEL Name=Searcharr Version=1.2
+LABEL Name=Searcharr Version=1.6
 
 WORKDIR /app
 ADD . /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 services:
   searcharr:
     container_name: searcharr
-    image: toddrob/searcharr:latest
+    image: ocgineer/searcharr:latest
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 services:
   searcharr:
     container_name: searcharr
-    image: ocgineer/searcharr:latest
+    image: toddrob/searcharr:latest
     volumes:
       - ./data:/app/data
       - ./logs:/app/logs

--- a/radarr.py
+++ b/radarr.py
@@ -85,7 +85,7 @@ class Radarr(object):
         quality=None,
         search=True,
         monitored=True,
-        tag=None,
+        tags=None,
     ):
         if not movie_info and not tmdb_id:
             return False
@@ -108,13 +108,24 @@ class Radarr(object):
             "monitored": monitored,
             "addOptions": {"searchForMovie": search},
         }
-        if tag:
-            if tag_id := self.get_tag_id(tag):
-                params.update({"tags": [tag_id]})
+        if tags:
+            if isinstance(tags, list):
+                tagids = []
+                for tag in tags:
+                    if tag_id := self.get_tag_id(tag):
+                        tagids.append(tag_id)
+                    else:
+                        self.logger.warning(
+                            f"Tag {tag} lookup/creation failed. The movie will not be tagged with {tag}."
+                        )
+                params.update({"tags": tagids})
             else:
-                self.logger.warning(
-                    "Tag lookup/creation failed. The movie will not be tagged."
-                )
+                if tag_id := self.get_tag_id(tags):
+                    params.update({"tags": [tag_id]})
+                else:
+                    self.logger.warning(
+                        "Tag lookup/creation failed. The movie will not be tagged."
+                    )
 
         return self._api_post("movie", params)
 

--- a/searcharr.py
+++ b/searcharr.py
@@ -551,8 +551,6 @@ class Searcharr(object):
                             tagslist.append(f"searcharr-{query.from_user.username if query.from_user.username else query.from_user.id}")
                         if settings.sonarr_anime_tag_with_anime:
                             tagslist.append("anime")
-                        if settings.sonarr_anime_tag_with_current:
-                            tagslist.append("anime-current-airing")
                         
                         added = self.sonarr.add_series(
                             series_info=r,
@@ -633,8 +631,6 @@ class Searcharr(object):
                         tagslist.append(f"searcharr-{query.from_user.username if query.from_user.username else query.from_user.id}")
                     if settings.sonarr_anime_tag_with_anime:
                         tagslist.append("anime")
-                    if settings.sonarr_anime_tag_with_current:
-                        tagslist.append("anime-current-airing")
                     
                     added = self.sonarr.add_series(
                         series_info=r,

--- a/searcharr.py
+++ b/searcharr.py
@@ -128,6 +128,20 @@ class Searcharr(object):
             logger.warning(
                 "No radarr_tag_with_username setting found. Please add radarr_tag_with_username to settings.py (radarr_tag_with_username=True or radarr_tag_with_username=False). Defaulting to True."
             )
+        try: # Handle missing sonarr_anime_enabled settings - added in 1.6
+            settings.sonarr_anime_enabled
+        except AttributeError:
+            settings.sonarr_anime_enabled = True
+            logger.warning(
+                "No sonarr_anime_enabled setting found. Please add sonarr_anime_enabled to settings.py (sonarr_anime_enabled=True or sonarr_anime_enabled=False). Defaulting to True."
+            )
+        try: # Handle missing sonarr_anime_tag_with_anime settings - added in 1.6
+            settings.sonarr_anime_tag_with_anime
+        except AttributeError:
+            settings.sonarr_anime_tag_with_anime = True
+            logger.warning(
+                "No sonarr_anime_tag_with_anime setting found. Please add sonarr_anime_tag_with_anime to settings.py (sonarr_anime_tag_with_anime=True or sonarr_anime_tag_with_anime=False). Defaulting to True."
+            )
 
     def cmd_start(self, update, context):
         logger.debug(f"Received start cmd from [{update.message.from_user.username}]")

--- a/settings-sample.py
+++ b/settings-sample.py
@@ -16,10 +16,13 @@ tgram_token = ""
 sonarr_enabled = True
 sonarr_url = ""  # http://192.168.0.100:8989
 sonarr_api_key = ""
-sonarr_quality_profile_id = "HD 720p"  # can be name or id value
+sonarr_quality_profile_id = "HD-720p"       # can be name or id value
 sonarr_add_monitored = True
 sonarr_search_on_add = True
 sonarr_tag_with_username = True
+sonarr_anime_enabled = True                 # enables the /anime command, sets the series type to anime
+sonarr_anime_tag_with_anime = True          # will tag the added anime with 'anime'
+sonarr_anime_tag_with_current = False       # will tag the added anime with 'anime-current-airing'
 
 # Radarr
 radarr_enabled = True

--- a/settings-sample.py
+++ b/settings-sample.py
@@ -22,7 +22,6 @@ sonarr_search_on_add = True
 sonarr_tag_with_username = True
 sonarr_anime_enabled = True                 # enables the /anime command, sets the series type to anime
 sonarr_anime_tag_with_anime = True          # will tag the added anime with 'anime'
-sonarr_anime_tag_with_current = False       # will tag the added anime with 'anime-current-airing'
 
 # Radarr
 radarr_enabled = True


### PR DESCRIPTION
Been a long time since I've attempted a pull request or coded in general but here goes.

I have added support for /anime command for Sonarr, which adds the selected 'series' as type anime, instead of standard. In addition, the add_series() and add_movies() can now accept a list of tags, instead of a single tag, the settings file will have two options for anime tagging as an example.