### PR TITLE
fix(readarr): forcibly search book

### DIFF
--- a/readarr.py
+++ b/readarr.py
@@ -129,7 +129,12 @@ class Readarr(object):
             },
         }
 
-        return self._api_post("book", params)
+        rsp = self._api_post("book", params)
+        if rsp is not None and search:
+            # Force book search
+            srsp = self._api_post("command", {"name": "BookSearch", "bookIds": [rsp.get("id")]})
+            self.logger.debug(f"Result of attempt to search book: {srsp}")
+        return rsp
 
     def get_root_folders(self):
         r = self._api_get("rootfolder", {})


### PR DESCRIPTION
Search book after adding. Since Readarr is still in develop, sometimes I notice that it doesn't search books on add, even when `searchForNewBook` is true :/
This calls a `BookSearch` command after adding the book to ensure Readarr searches for the book.

Related: https://github.com/toddrob99/searcharr/pull/59