### PR TITLE
Updated to sonarr api v3 in order to work in sonarr 4.x

### DIFF
--- a/sonarr.py
+++ b/sonarr.py
@@ -22,7 +22,7 @@ class Sonarr(object):
             self.logger.error(
                 "Invalid Sonarr URL detected. Please update your settings to include http:// or https:// on the beginning of the URL."
             )
-        self.api_url = api_url + "/api/{endpoint}?apikey=" + api_key
+        self.api_url = api_url + "/api/v3/{endpoint}?apikey=" + api_key
         self._quality_profiles = self.get_all_quality_profiles()
         self._root_folders = self.get_root_folders()
         self._all_series = {}
@@ -38,7 +38,7 @@ class Sonarr(object):
         return [
             {
                 "title": x.get("title"),
-                "seasonCount": x.get("seasonCount", 0),
+                "seasonCount": len(x.get("seasons")),
                 "status": x.get("status", "Unknown Status"),
                 "overview": x.get("overview", "Overview not available."),
                 "network": x.get("network"),
@@ -141,7 +141,7 @@ class Sonarr(object):
             "tags": tag_ids,
             "addOptions": {
                 "ignoreEpisodesWithFiles": unmonitor_existing,
-                "ignoreEpisodesWithoutFiles": "false",
+                "ignoreEpisodesWithoutFiles": False,
                 "searchForMissingEpisodes": search,
             },
         }
@@ -227,7 +227,7 @@ class Sonarr(object):
         )
 
     def get_all_quality_profiles(self):
-        return self._api_get("profile", {}) or None
+        return self._api_get("qualityprofile", {}) or None
 
     def lookup_root_folder(self, v):
         # Look up root folder from a path or id


### PR DESCRIPTION
as seem on issue #63 , the new 4.0 sonarr version has dropped support for the legacy API, the v3 is the current stable release and should work for everybody using the current sonarr version 3.0 and newer. 
This might break support with legacy sonarr version (like 2.0) if this support is required, I can update the PR to add support for this legacy versions.