### PR TITLE
Update sonarr.py because of duplicated v3 call

### DIFF
--- a/sonarr.py
+++ b/sonarr.py
@@ -246,7 +246,7 @@ class Sonarr(object):
         return self._api_get("qualityprofile", {}) or None
 
     def get_all_language_profiles(self):
-        return self._api_get("v3/languageprofile", {}) or None
+        return self._api_get("languageprofile", {}) or None
 
     def lookup_root_folder(self, v):
         # Look up root folder from a path or id


### PR DESCRIPTION
Since the change to the base url and the changes for language profile, the v3 was duplicated and causing errors