### PR TITLE
fix: prevent silent polling death (zombie bot) — timeouts, bootstrap retries, liveness watchdog

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -141,4 +141,4 @@ venv.bak/
 /site
 
 # mypy
-.mypy_cache/
+.mypy_cache/settings.py

--- a/bot/searcharr_bot.py
+++ b/bot/searcharr_bot.py
@@ -5,6 +5,11 @@ Main Bot Class
 By Todd Roberts
 https://github.com/toddrob99/searcharr
 """
+import os
+import sys
+import threading
+import time
+
 from telegram.ext import ApplicationBuilder, CallbackQueryHandler
 
 from api.sonarr import Sonarr
@@ -110,24 +115,85 @@ class SearcharrBot:
         except Exception:
             pass
     
+    def _start_liveness_watchdog(self, application):
+        """Exit the process if the polling loop dies so the container restart
+        policy can recover us.
+
+        Failure history this guards against: the getUpdates loop has twice
+        stopped while the process stayed alive (2026-06-19 boot-time DNS
+        failure, 2026-07-13 Bad Gateway storm) — a zombie state that
+        `restart: always` can never fix because the process never exits.
+        Fail-fast + Docker restart is the recovery path.
+        """
+        def watch():
+            time.sleep(180)  # grace period for startup
+            misses = 0
+            while True:
+                time.sleep(60)
+                alive = False
+                try:
+                    alive = bool(
+                        application.running
+                        and application.updater is not None
+                        and application.updater.running
+                    )
+                except Exception:
+                    alive = False
+                if alive:
+                    misses = 0
+                else:
+                    misses += 1
+                    self.logger.warning(
+                        f"Liveness check failed ({misses}/3): polling loop not running"
+                    )
+                    if misses >= 3:
+                        self.logger.critical(
+                            "Polling loop is dead — exiting so the container restart policy can recover."
+                        )
+                        os._exit(75)  # EX_TEMPFAIL
+
+        t = threading.Thread(target=watch, daemon=True, name="liveness-watchdog")
+        t.start()
+
     def run(self):
         """Initialize and run the Telegram bot."""
         self.logger.info("Starting Searcharr bot...")
-        
-        # Build the application
-        application = ApplicationBuilder().token(self.token).job_queue(None).build()
-        
+
+        # Build the application. Explicit getUpdates timeouts prevent the
+        # long-poll from hanging forever on a silently-dropped connection
+        # (the 2026-07-13 zombie: Bad Gateway storm, then a stalled poll).
+        application = (
+            ApplicationBuilder()
+            .token(self.token)
+            .job_queue(None)
+            .get_updates_connect_timeout(10)
+            .get_updates_read_timeout(30)
+            .get_updates_write_timeout(10)
+            .get_updates_pool_timeout(10)
+            .build()
+        )
+
         # Register command handlers from each module
         register_commands(application, self)
-        
+
         # Register the main callback handler
         application.add_handler(CallbackQueryHandler(main_callback_handler(self)))
-        
+
         # Add error handler if not in dev mode
         if not self.dev_mode:
             application.add_error_handler(self._handle_error)
         else:
             self.logger.info("Developer mode is enabled; skipping registration of error handler--exceptions will be raised.")
-        
-        # Start the bot
-        application.run_polling()
+
+        # Watchdog: if polling dies without killing the process, exit so
+        # Docker restarts us instead of leaving a zombie.
+        self._start_liveness_watchdog(application)
+
+        # Start the bot. bootstrap_retries=-1 retries network failures during
+        # startup indefinitely (the 2026-06-19 crash: DNS not ready at boot
+        # killed the bot instead of retrying).
+        try:
+            application.run_polling(bootstrap_retries=-1)
+        except Exception as e:
+            self.logger.critical(f"Bot terminated with unhandled exception: {e!r}")
+            sys.exit(1)


### PR DESCRIPTION
## Problem

The bot can end up in a zombie state: the getUpdates polling loop dies, but the process stays alive — so `restart: always` never fires and the bot silently stops responding until someone notices and manually restarts the container. I hit this twice in production:

1. **Boot-time network failure**: container started before DNS was ready → `telegram.error.NetworkError: httpx.ConnectError: [Errno -3] Temporary failure in name resolution` → bot dead on arrival. `run_polling()` uses `bootstrap_retries=0` by default, so a single startup network error is fatal.
2. **Mid-flight stall**: a Telegram `Bad Gateway` storm (5 errors logged through the error handler in ~20s), after which polling went silent for 2.5 hours with the process still running. With no explicit `get_updates_*` timeouts, a silently dropped long-poll connection can stall indefinitely.

In both cases `docker ps` shows the container healthy and `Up`, while the bot is unresponsive in Telegram.

## Fix (three layers)

1. **Explicit getUpdates timeouts** (`connect 10s / read 30s / write 10s / pool 10s`) — a dropped connection now surfaces as an error PTB can retry, instead of hanging the polling task forever.
2. **`run_polling(bootstrap_retries=-1)`** — startup network failures retry indefinitely instead of killing the bot (containers frequently race DNS/network at boot).
3. **Liveness watchdog + fail-fast** — a daemon thread checks `application.running` / `updater.running` every 60s (3-minute startup grace); after 3 consecutive failures it logs CRITICAL and exits 75 so the container restart policy can recover. Unhandled exceptions escaping `run_polling()` now `sys.exit(1)` for the same reason. A crashed bot that restarts in seconds beats a zombie that's dead for days.

## Notes

- Verified against python-telegram-bot 22.7 (the version installed by requirements) — `bootstrap_retries` default confirmed 0, all `get_updates_*` builder methods present.
- No behavior change for healthy operation; dev mode (`-d`) behavior unchanged.
- Running in production since 2026-07-13 — clean startup, stable polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUNvRCXML3DJe98KBCGkN