### PR TITLE
Add Sportarr support with /sport command

### DIFF
--- a/api/api_client.py
+++ b/api/api_client.py
@@ -109,6 +109,9 @@ class ApiClient(object):
             if self.version and self.version.startswith("4."):
                 return f"{api_url}/api/v3/{{endpoint}}?apikey={api_key}"
             return f"{api_url}/api/{{endpoint}}?apikey={api_key}"
+        elif self.service_name == "sportarr":
+            # Sportarr has always exposed the v3-compatible surface.
+            return f"{api_url}/api/v3/{{endpoint}}?apikey={api_key}"
         elif self.service_name == "radarr":
             if self.version and not self.version.startswith("0."):
                 return f"{api_url}/api/v3/{{endpoint}}?apikey={api_key}"

--- a/api/sportarr.py
+++ b/api/sportarr.py
@@ -1,0 +1,25 @@
+"""
+Searcharr
+Sonarr & Radarr Telegram Bot
+Sportarr API Wrapper
+By Todd Roberts
+https://github.com/toddrob99/searcharr
+"""
+from .sonarr import Sonarr
+
+
+class Sportarr(Sonarr):
+    """Sportarr (https://github.com/Sportarr/Sportarr) is a sports event
+    manager exposing a Sonarr-v3-compatible API: series lookup, root
+    folders, quality profiles, tags and series add all behave like
+    Sonarr's, with leagues surfacing as series and events as episodes.
+    The Sonarr wrapper therefore drives it as-is; only the service name
+    differs so logs and settings stay clearly labeled.
+    """
+
+    def __init__(self, api_url, api_key, verbose=False):
+        # Skip Sonarr.__init__ on purpose: it pins the service name to
+        # "sonarr". Replicate its body with the sportarr service name.
+        super(Sonarr, self).__init__(api_url, api_key, "sportarr", verbose)
+        self._all_series = {}
+        self.get_all_series()

--- a/bot/callbacks/callback_handler.py
+++ b/bot/callbacks/callback_handler.py
@@ -10,6 +10,7 @@ from bot.utils.log import set_up_logger
 
 # Import service-specific callback handlers
 from bot.callbacks.sonarr_callbacks import handle_sonarr_callback
+from bot.callbacks.sportarr_callbacks import handle_sportarr_callback
 from bot.callbacks.radarr_callbacks import handle_radarr_callback
 from bot.callbacks.user_callbacks import handle_user_callback
 
@@ -59,6 +60,8 @@ def main_callback_handler(bot):
         try:
             if convo["type"] == "series":
                 await handle_sonarr_callback(update, context, bot, convo, cid, i, op, op_flags)
+            elif convo["type"] == "sport":
+                await handle_sportarr_callback(update, context, bot, convo, cid, i, op, op_flags)
             elif convo["type"] == "movie":
                 await handle_radarr_callback(update, context, bot, convo, cid, i, op, op_flags)
             elif convo["type"] == "users":

--- a/bot/callbacks/sportarr_callbacks.py
+++ b/bot/callbacks/sportarr_callbacks.py
@@ -1,0 +1,194 @@
+"""
+Searcharr
+Sonarr & Radarr Telegram Bot
+Sportarr-Specific Callback Handlers
+By Todd Roberts
+https://github.com/toddrob99/searcharr
+"""
+from bot.utils.conversation import get_add_data, update_add_data, delete_conversation
+from bot.utils.formatting import prepare_response
+from bot.utils.text import translate
+from bot.utils.log import set_up_logger
+from bot.callbacks.base import (
+    handle_navigation,
+    handle_cancel,
+    check_path_selection,
+    check_quality_selection,
+    handle_tag_selection,
+    process_tags,
+    update_media_message
+)
+import settings
+
+logger = set_up_logger("callbacks.sportarr")
+
+# Create a config object for Sportarr-specific settings
+SPORTARR_CONFIG = {
+    "tag_with_username": settings.sportarr_tag_with_username,
+    "forced_tags": settings.sportarr_forced_tags,
+    "allow_user_to_select_tags": settings.sportarr_allow_user_to_select_tags,
+    "user_selectable_tags": settings.sportarr_user_selectable_tags,
+    "add_monitored": settings.sportarr_add_monitored,
+    "search_on_add": settings.sportarr_search_on_add,
+    "season_monitor_prompt": settings.sportarr_season_monitor_prompt
+}
+
+
+async def handle_sportarr_callback(update, context, bot, convo, cid, i, op, op_flags):
+    """Handle callbacks related to Sportarr (series).
+    
+    Args:
+        update: The update with the callback query
+        context: The callback context
+        bot: The SearcharrBot instance
+        convo: The conversation data
+        cid: The conversation ID
+        i: The current index
+        op: The operation
+        op_flags: Additional operation flags
+    """
+    query = update.callback_query
+    
+    # Handle operations
+    if op == "add":
+        await handle_add_sport(update, context, bot, convo, cid, i, op_flags)
+    elif op == "prev" or op == "next":
+        await handle_navigation(update, context, "sport", convo, cid, i, op)
+    elif op == "cancel" or op == "done":
+        await handle_cancel(update, context, convo, cid, i, op)
+    else:
+        # Default action for unrecognized operations
+        await query.answer()
+
+
+async def handle_add_sport(update, context, bot, convo, cid, i, op_flags):
+    """Handle adding a series to Sportarr.
+    
+    Args:
+        update: The update with the callback query
+        context: The callback context
+        bot: The SearcharrBot instance
+        convo: The conversation data
+        cid: The conversation ID
+        i: The current index
+        op_flags: Additional operation flags
+    """
+    query = update.callback_query
+    service = bot.sportarr
+    
+    # Get the series result
+    r = convo["results"][i]
+    
+    # If we have flags, process them first
+    if op_flags:
+        for k, v in op_flags.items():
+            logger.debug(f"Adding/Updating additional data for cid=[{cid}], key=[{k}], value=[{v}]...")
+            update_add_data(cid, k, v)
+        
+        # If this is a tag selection, handle it and return
+        if op_flags.get("tt") or op_flags.get("td"):
+            handled = await handle_tag_selection(update, context, service, SPORTARR_CONFIG, convo, cid, i, op_flags)
+            if handled:
+                return
+    
+    # Get the additional data that has been collected so far
+    additional_data = get_add_data(cid)
+    logger.debug(f"Additional data: {additional_data}")
+    
+    # Step 1: Check for root folder selection
+    if not await check_path_selection(update, context, service, "sport", convo, cid, i):
+        return
+    
+    # Step 2: Check for quality profile selection
+    if not await check_quality_selection(update, context, service, "sport", convo, cid, i):
+        return
+    
+    # Step 3: Check for season monitor options
+    if (
+        SPORTARR_CONFIG["season_monitor_prompt"]
+        and additional_data.get("m", False) is False
+    ):
+        # Need to prompt user to select season monitoring option
+        monitor_options = [
+            translate("all_seasons"),
+            translate("first_season"),
+            translate("latest_season"),
+        ]
+        reply_message, reply_markup = prepare_response(
+            "sport",
+            r,
+            cid,
+            i,
+            len(convo["results"]),
+            add=True,
+            monitor_options=monitor_options,
+        )
+        await update_media_message(
+                query.message,
+                r["remotePoster"],
+                caption=reply_message,
+                reply_markup=reply_markup
+            )
+        await query.answer()
+        return
+    
+    # Step 4: Check for tag selection
+    if SPORTARR_CONFIG["allow_user_to_select_tags"] and not additional_data.get("td"):
+        all_tags = service.get_filtered_tags(
+            SPORTARR_CONFIG["user_selectable_tags"],
+            SPORTARR_CONFIG["forced_tags"],
+        )
+        
+        if not all_tags:
+            logger.warning(
+                "User tagging is enabled, but no tags found. Make sure there are tags in Sportarr matching your Searcharr configuration."
+            )
+        elif not additional_data.get("tt"):
+            # Need to prompt user to select tags
+            reply_message, reply_markup = prepare_response(
+                "sport",
+                r,
+                cid,
+                i,
+                len(convo["results"]),
+                add=True,
+                tags=all_tags,
+            )
+            await update_media_message(
+                query.message,
+                r["remotePoster"],
+                caption=reply_message,
+                reply_markup=reply_markup
+            )
+            await query.answer()
+            return
+    
+    # Step 5: Process tags (username tag and forced tags)
+    await process_tags(service, SPORTARR_CONFIG, cid, query.from_user)
+    
+    # Step 6: All data collected, add the series
+    logger.debug("All data is accounted for, proceeding to add...")
+    try:
+        added = service.add_series(
+            series_info=r,
+            monitored=SPORTARR_CONFIG["add_monitored"],
+            search=SPORTARR_CONFIG["search_on_add"],
+            additional_data=get_add_data(cid),
+        )
+    except Exception as e:
+        logger.error(f"Error adding series: {e}")
+        added = False
+    
+    logger.debug(f"Result of attempt to add series: {added}")
+    
+    # Step 7: Handle the result
+    if added:
+        delete_conversation(cid)
+        await query.message.reply_text(translate("added", title=r["title"]))
+        await query.message.delete()
+    else:
+        await query.message.reply_text(
+            translate("unknown_error_adding", kind="sport")
+        )
+    
+    await query.answer()

--- a/bot/commands/__init__.py
+++ b/bot/commands/__init__.py
@@ -11,6 +11,7 @@ import settings
 from bot.commands.start import start_command
 from bot.commands.help import help_command
 from bot.commands.series import series_command
+from bot.commands.sport import sport_command
 from bot.commands.movie import movie_command
 from bot.commands.users import users_command
 
@@ -46,6 +47,14 @@ def register_commands(application, bot):
                 CommandHandler(cmd, lambda update, context: series_command(update, context, bot))
             )
     
+    # Register sport commands if sportarr is enabled
+    if bot.sportarr:
+        for cmd in settings.sportarr_sport_command_aliases:
+            logger.debug(f"Registering [/{cmd}] as a sport command")
+            application.add_handler(
+                CommandHandler(cmd, lambda update, context: sport_command(update, context, bot))
+            )
+
     # Register movie commands if radarr is enabled
     if bot.radarr:
         for cmd in settings.radarr_movie_command_aliases:

--- a/bot/commands/help.py
+++ b/bot/commands/help.py
@@ -56,6 +56,20 @@ async def help_command(update, context, bot):
             )
         )
     
+    # Sportarr help
+    if settings.sportarr_enabled:
+        help_text.append(
+            translate(
+                "help_sportarr",
+                sport_commands=" OR ".join(
+                    [
+                        f"`/{c} {translate('title').title()}`"
+                        for c in settings.sportarr_sport_command_aliases
+                    ]
+                ),
+            )
+        )
+
     # Radarr help
     if settings.radarr_enabled:
         help_text.append(

--- a/bot/commands/sport.py
+++ b/bot/commands/sport.py
@@ -1,0 +1,109 @@
+"""
+Searcharr
+Sonarr & Radarr Telegram Bot
+Sport Command Handler
+By Todd Roberts
+https://github.com/toddrob99/searcharr
+"""
+from telegram.error import BadRequest
+
+from bot.utils.conversation import generate_cid, create_conversation
+from bot.utils.auth import authenticated
+from bot.utils.text import strip_entities, translate
+from bot.utils.formatting import prepare_response
+import settings
+
+
+async def sport_command(update, context, bot):
+    """Handle the /sport command to search for and add sports leagues."""
+    logger = bot.logger
+    logger.debug(f"Received sport cmd from [{update.message.from_user.username}]")
+    
+    # Check authentication
+    if not authenticated(update.message.from_user.id):
+        await update.message.reply_text(
+            translate(
+                "auth_required",
+                commands=" OR ".join(
+                    [
+                        f"`/{c} <{translate('password')}>`"
+                        for c in settings.searcharr_start_command_aliases
+                    ]
+                ),
+            )
+        )
+        return
+    
+    # Check if sportarr is enabled
+    if not settings.sportarr_enabled:
+        await update.message.reply_text(translate("sportarr_disabled"))
+        return
+    
+    # Extract title from message
+    title = strip_entities(update.message)
+    if not title:
+        x_title = translate("title").title()
+        await update.message.reply_text(
+            translate(
+                "include_sport_title_in_cmd",
+                commands=" OR ".join(
+                    [
+                        f"`/{c} {x_title}`"
+                        for c in settings.sportarr_sport_command_aliases
+                    ]
+                ),
+            )
+        )
+        return
+    
+    # Look up series
+    results = bot.sportarr.lookup_series(title)
+
+    # Handle no results before touching the database
+    if not results:
+        await update.message.reply_text(translate("no_matching_sport"))
+        return
+
+    cid = generate_cid()
+    if not cid:
+        await update.message.reply_text(translate("unexpected_error"))
+        return
+
+    create_conversation(
+        id=cid,
+        username=str(update.message.from_user.username),
+        kind="sport",
+        results=results,
+    )
+    
+    # Prepare response for first result
+    r = results[0]
+    reply_message, reply_markup = prepare_response(
+        "sport", r, cid, 0, len(results)
+    )
+    
+    # Send response with photo
+    try:
+        await context.bot.sendPhoto(
+            chat_id=update.message.chat.id,
+            photo=r["remotePoster"],
+            caption=reply_message,
+            reply_markup=reply_markup,
+        )
+    except BadRequest as e:
+        if str(e) in [
+            "Wrong type of the web page content",
+            "Wrong file identifier/http url specified",
+            "Media_empty",
+        ]:
+            logger.error(
+                f"Error sending photo [{r['remotePoster']}]: BadRequest: {e}. Attempting to send with default poster..."
+            )
+            await context.bot.sendPhoto(
+                chat_id=update.message.chat.id,
+                photo="https://artworks.thetvdb.com/banners/images/missing/movie.jpg",
+                caption=reply_message,
+                reply_markup=reply_markup,
+            )
+        else:
+            raise

--- a/bot/searcharr_bot.py
+++ b/bot/searcharr_bot.py
@@ -8,6 +8,7 @@ https://github.com/toddrob99/searcharr
 from telegram.ext import ApplicationBuilder, CallbackQueryHandler
 
 from api.sonarr import Sonarr
+from api.sportarr import Sportarr
 from api.radarr import Radarr
 from bot.utils.log import set_up_logger
 from bot.utils.database import init_db
@@ -41,6 +42,7 @@ class SearcharrBot:
         
         # Initialize service clients
         self.sonarr = self._init_service("sonarr", verbose)
+        self.sportarr = self._init_service("sportarr", verbose)
         self.radarr = self._init_service("radarr", verbose)
         
         # Check and validate settings
@@ -78,6 +80,11 @@ class SearcharrBot:
                 client = Sonarr(settings.sonarr_url, settings.sonarr_api_key, verbose)
                 return configure_sonarr(client)
             
+            elif service_name == "sportarr":
+                from bot.services.sportarr_service import configure_sportarr
+                client = Sportarr(settings.sportarr_url, settings.sportarr_api_key, verbose)
+                return configure_sportarr(client)
+
             elif service_name == "radarr":
                 from bot.services.radarr_service import configure_radarr
                 client = Radarr(settings.radarr_url, settings.radarr_api_key, verbose)

--- a/bot/services/sportarr_service.py
+++ b/bot/services/sportarr_service.py
@@ -1,0 +1,205 @@
+"""
+Searcharr
+Sonarr & Radarr Telegram Bot
+Sportarr Service Configuration
+By Todd Roberts
+https://github.com/toddrob99/searcharr
+"""
+from bot.utils.log import set_up_logger
+import settings
+
+logger = set_up_logger("sportarr_service")
+
+
+def configure_sportarr(client):
+    """Configure the Sportarr client.
+    
+    Args:
+        client: The Sportarr client
+        
+    Returns:
+        object: The configured Sportarr client
+    """
+    # Configure quality profiles
+    client = _configure_quality_profiles(client)
+    
+    # Configure root folders
+    client = _configure_root_folders(client)
+    
+    # Configure tags
+    _configure_tags(client)
+    
+    # Check service-specific settings
+    _check_service_settings()
+    
+    return client
+
+
+def _configure_quality_profiles(client):
+    """Configure quality profiles for Sportarr.
+    
+    Args:
+        client: The Sportarr client
+        
+    Returns:
+        object: The Sportarr client with configured quality profiles
+    """
+    quality_profiles = []
+    setting_name = "sportarr_quality_profile_id"
+    
+    profile_setting = getattr(settings, setting_name, [])
+    if not isinstance(profile_setting, list):
+        setattr(settings, setting_name, [profile_setting])
+        profile_setting = [profile_setting]
+        
+    for i in profile_setting:
+        logger.debug(f"Looking up/validating Sportarr quality profile id for [{i}]...")
+        foundProfile = client.lookup_quality_profile(i)
+        
+        if not foundProfile:
+            logger.error(f"Sportarr quality profile id/name [{i}] is invalid!")
+        else:
+            logger.debug(f"Found Sportarr quality profile for [{i}]: [{foundProfile}]")
+            quality_profiles.append(foundProfile)
+            
+    if not quality_profiles:
+        logger.warning(
+            f"No valid Sportarr quality profile(s) provided! "
+            f"Using all of the quality profiles found in Sportarr: {client._quality_profiles}"
+        )
+    else:
+        logger.debug(
+            f"Using the following Sportarr quality profile(s): "
+            f"{[(x['id'], x['name']) for x in quality_profiles]}"
+        )
+        client._quality_profiles = quality_profiles
+        
+    return client
+
+
+def _configure_root_folders(client):
+    """Configure root folders for Sportarr.
+    
+    Args:
+        client: The Sportarr client
+        
+    Returns:
+        object: The Sportarr client with configured root folders
+    """
+    setting_name = "sportarr_series_paths"
+    
+    root_folders = []
+    
+    if not hasattr(settings, setting_name):
+        setattr(settings, setting_name, [])
+        logger.warning(
+            f"No {setting_name} setting detected. Please set one in settings.py "
+            f"({setting_name}=[\"/path/1\", \"/path/2\"]). Proceeding with all root folders configured in Sportarr."
+        )
+        
+    paths_setting = getattr(settings, setting_name)
+    if not isinstance(paths_setting, list):
+        setattr(settings, setting_name, [paths_setting])
+        paths_setting = [paths_setting]
+        
+    for i in paths_setting:
+        logger.debug(f"Looking up/validating Sportarr root folder for [{i}]...")
+        foundPath = client.lookup_root_folder(i)
+        
+        if not foundPath:
+            logger.error(f"Sportarr root folder path/id [{i}] is invalid!")
+        else:
+            logger.debug(f"Found Sportarr root folder for [{i}]: [{foundPath}]")
+            root_folders.append(foundPath)
+            
+    if not root_folders:
+        logger.warning(
+            f"No valid Sportarr root folder(s) provided! "
+            f"Using all of the root folders found in Sportarr: {client._root_folders}"
+        )
+    else:
+        logger.debug(
+            f"Using the following Sportarr root folder(s): "
+            f"{[(x['id'], x['path']) for x in root_folders]}"
+        )
+        client._root_folders = root_folders
+        
+    return client
+
+
+def _configure_tags(client):
+    """Configure tags for Sportarr.
+    
+    Args:
+        client: The Sportarr client
+    """
+    # Process forced tags
+    forced_tags = getattr(settings, "sportarr_forced_tags", [])
+    
+    for t in forced_tags:
+        if t_id := client.get_tag_id(t):
+            logger.debug(f"Tag id [{t_id}] for forced Sportarr tag [{t}]")
+            
+    # Process user-selectable tags
+    user_tags = getattr(settings, "sportarr_user_selectable_tags", [])
+    
+    for t in user_tags:
+        if t_id := client.get_tag_id(t):
+            logger.debug(f"Tag id [{t_id}] for user-selectable Sportarr tag [{t}]")
+
+
+def _check_service_settings():
+    """Check and set defaults for Sportarr settings."""
+    # Check tag_with_username setting
+    if not hasattr(settings, "sportarr_tag_with_username"):
+        settings.sportarr_tag_with_username = True
+        logger.warning(
+            "No sportarr_tag_with_username setting found. Please add sportarr_tag_with_username to settings.py "
+            "(sportarr_tag_with_username=True or sportarr_tag_with_username=False). Defaulting to True."
+        )
+        
+    # Check command aliases setting
+    if not hasattr(settings, "sportarr_sport_command_aliases"):
+        settings.sportarr_sport_command_aliases = ["sport"]
+        logger.warning(
+            "No sportarr_sport_command_aliases setting found. Please add sportarr_sport_command_aliases to settings.py "
+            '(e.g. sportarr_sport_command_aliases=["sport", "sp"]). '
+            'Defaulting to ["sport"].'
+        )
+        
+    # Check forced tags setting
+    if not hasattr(settings, "sportarr_forced_tags"):
+        settings.sportarr_forced_tags = []
+        logger.warning(
+            "No sportarr_forced_tags setting found. Please add sportarr_forced_tags to settings.py "
+            '(e.g. sportarr_forced_tags=["tag-1", "tag-2"]) if you want specific tags '
+            "added to each series. Defaulting to empty list ([])."
+        )
+        
+    # Check user_selectable_tags setting
+    if not hasattr(settings, "sportarr_user_selectable_tags"):
+        settings.sportarr_user_selectable_tags = []
+        logger.warning(
+            "No sportarr_user_selectable_tags setting found. Please add sportarr_user_selectable_tags to settings.py "
+            '(e.g. sportarr_user_selectable_tags=["tag-1", "tag-2"]) if you want to limit the tags '
+            "a user can select. Defaulting to empty list ([]), which will present the user with all tags."
+        )
+        
+    # Check allow_user_to_select_tags setting
+    if not hasattr(settings, "sportarr_allow_user_to_select_tags"):
+        settings.sportarr_allow_user_to_select_tags = False
+        logger.warning(
+            "No sportarr_allow_user_to_select_tags setting found. Please add sportarr_allow_user_to_select_tags to settings.py "
+            "(e.g. sportarr_allow_user_to_select_tags=True) "
+            "if you want users to be able to select tags "
+            "when adding a series. Defaulting to False."
+        )
+        
+    # Check season_monitor_prompt setting
+    if not hasattr(settings, "sportarr_season_monitor_prompt"):
+        settings.sportarr_season_monitor_prompt = False
+        logger.warning(
+            "No sportarr_season_monitor_prompt setting found. Please add sportarr_season_monitor_prompt to settings.py "
+            "(e.g. sportarr_season_monitor_prompt=True if you want users to choose whether to monitor "
+            "all/first/latest season(s). Defaulting to False."
+        )

--- a/bot/utils/formatting.py
+++ b/bot/utils/formatting.py
@@ -66,7 +66,8 @@ def prepare_response(
                 "TMDB", url=f"https://www.themoviedb.org/movie/{r['tmdbId']}"
             )
         )
-    # Add IMDb links for movies and series
+    # Add IMDb links for movies and series (sport results carry alias ids,
+    # not real TVDB/IMDb entries, so no external links for them)
     if kind in ["series", "movie"]:
         if r["imdbId"]:
             keyboardNavRow.append(
@@ -189,6 +190,10 @@ def prepare_response(
     # Create message text based on content type
     if kind == "series":
         reply_message = f"{r['title']}{' (' + str(r['year']) + ')' if r['year'] and str(r['year']) not in r['title'] else ''} - {r['seasonCount']} Season{'s' if r['seasonCount'] != 1 else ''}{' - ' + r['network'] if r['network'] else ''} - {r['status'].title()}\n\n{r['overview']}"[
+            0:1024
+        ]
+    elif kind == "sport":
+        reply_message = f"{r['title']}{' (' + str(r['year']) + ')' if r['year'] and str(r['year']) not in r['title'] else ''} - {r['seasonCount']} Season{'s' if r['seasonCount'] != 1 else ''} - {r['status'].title()}\n\n{r['overview']}"[
             0:1024
         ]
     elif kind == "movie":

--- a/lang/en-us.yml
+++ b/lang/en-us.yml
@@ -59,3 +59,8 @@ help_sonarr: Use {series_commands} to add a series to Sonarr.
 help_radarr: Use {movie_commands} to add a movie to Radarr.
 no_features: Sorry, but all of my features are currently disabled.
 admin_help: Since you are an admin, you can also use {commands} to manage users.
+sport: league
+sportarr_disabled: Sorry, but sports support is disabled.
+include_sport_title_in_cmd: Please include the league name in the command, e.g. {commands}
+no_matching_sport: Sorry, but I didn't find any matching leagues.
+help_sportarr: Use {sport_commands} to add a sports league to Sportarr.

--- a/settings-sample.py
+++ b/settings-sample.py
@@ -31,6 +31,21 @@ sonarr_series_command_aliases = ["series"]  # e.g. ["series", "tv", "t"]
 sonarr_series_paths = []  # e.g. ["/tv", "/anime"] - can be full path or id value - leave empty to enable all
 sonarr_season_monitor_prompt = False  # False - always monitor all seasons; True - prompt user to select from All, First, or Latest season(s)
 
+# Sportarr
+sportarr_enabled = False
+sportarr_url = ""  # http://192.168.0.100:1867
+sportarr_api_key = ""
+sportarr_quality_profile_id = ["HD - 720p/1080p"]  # can be name or id value - include multiple to allow the user to choose
+sportarr_add_monitored = True
+sportarr_search_on_add = True
+sportarr_tag_with_username = True
+sportarr_forced_tags = []  # e.g. ["searcharr", "friends-and-family"] - leave empty for none
+sportarr_allow_user_to_select_tags = True
+sportarr_user_selectable_tags = []  # e.g. ["custom-tag-1", "custom-tag-2"] - leave empty to let user choose from all tags in Sportarr
+sportarr_sport_command_aliases = ["sport"]  # e.g. ["sport", "league", "sp"]
+sportarr_series_paths = []  # e.g. ["/sports"] - can be full path or id value - leave empty to enable all
+sportarr_season_monitor_prompt = False  # False - always monitor all seasons; True - prompt user to select from All, First, or Latest season(s)
+
 # Radarr
 radarr_enabled = True
 radarr_url = ""  # http://192.168.0.100:7878


### PR DESCRIPTION

Sportarr (https://github.com/Sportarr/Sportarr) is a sports event manager
in the arr family exposing a Sonarr-v3-compatible API. This adds it as a
third service next to Sonarr and Radarr:

- `api/sportarr.py`: thin subclass of the Sonarr wrapper (the v3 surface
  behaves identically; leagues surface as series).
- `/sport` command (aliases configurable via
  `sportarr_sport_command_aliases`), its own conversation kind, callbacks
  and help text; sport results skip TVDB/IMDb link buttons since league
  ids are aliases, not real TVDB entries.
- `sportarr_*` settings block mirroring the sonarr block, disabled by
  default, plus en-us strings (other languages fall back to English).

I maintain Sportarr; happy to adjust anything to fit the project.

